### PR TITLE
Add move history navigation and notation

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,14 @@
         </select>
     </div>
     <div id="boardArea">
-        <div id="chessboard"></div>
-        <div id="evalBar"><div id="evalFill"></div></div>
+        <div id="boardWrapper">
+            <div id="chessboard"></div>
+            <div id="evalBar"><div id="evalFill"></div></div>
+        </div>
+        <div id="historyColumn">
+            <div class="history-header">Move History</div>
+            <div id="moveHistoryList"></div>
+        </div>
     </div>
     <script src="stockfish.js"></script>
     <script src="chess.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,13 @@ body {
 
 #boardArea {
     display: flex;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+#boardWrapper {
+    display: flex;
+    align-items: flex-start;
 }
 
 #evalBar {
@@ -114,6 +121,94 @@ body {
     margin-left: 5px;
     position: relative;
     background: #000;
+}
+
+#historyColumn {
+    width: 220px;
+    height: 560px;
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+}
+
+.history-header {
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 8px;
+    font-size: 16px;
+}
+
+#moveHistoryList {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 6px;
+    min-height: 0;
+}
+
+.history-start {
+    padding: 6px 8px;
+    border-radius: 6px;
+    background: #f7f7f7;
+    margin-bottom: 8px;
+    text-align: center;
+    font-size: 13px;
+    color: #555;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.history-start:hover {
+    background: #e8e8e8;
+}
+
+.history-start.active {
+    background: #4caf50;
+    color: #fff;
+}
+
+.move-row {
+    display: grid;
+    grid-template-columns: 36px 1fr 1fr;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    padding: 4px 0;
+    border-bottom: 1px solid #eee;
+}
+
+.move-row:last-child {
+    border-bottom: none;
+}
+
+.move-number {
+    text-align: right;
+    color: #777;
+    font-weight: 500;
+}
+
+.move {
+    padding: 2px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    white-space: nowrap;
+}
+
+.move:hover {
+    background: #f0f0f0;
+}
+
+.move.active {
+    background: #4caf50;
+    color: #fff;
+}
+
+.move.empty {
+    cursor: default;
+    color: #bbb;
 }
 
 #evalFill {


### PR DESCRIPTION
## Summary
- Add a right-hand move history column to the layout with supporting styles for the board area.
- Track moves in standard algebraic notation, capture board states, and render a clickable move list to review positions.
- Enable navigating the move list with mouse clicks or keyboard arrows while keeping the board and evaluation bar in sync.

## Testing
- node --check chess.js

------
https://chatgpt.com/codex/tasks/task_e_68d1bdc93d70832da051a822187623e0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Move History panel with clickable entries and Arrow key navigation.
  * Enhanced pawn promotion with an on-screen selection flow.
  * Improved reset and replay: navigate to past positions and re-render the board.
  * Bot selection visibility now toggles based on game mode.

* **Style**
  * Updated layout: board and evaluation bar grouped; new side History column.
  * Added refined spacing, hover, and active states for history items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->