### PR TITLE
Add custom mix bot configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,14 @@
         <select id="botDifficulty">
             <option value="random">Random Moves</option>
             <option value="stockfish">Stockfish</option>
+            <option value="custom">Custom mix</option>
         </select>
+        <div id="customMixContainer" class="custom-mix-container" style="display: none;">
+            <p class="custom-mix-description">Select at least two bots and distribute their turn percentages. Values snap to 5% increments.</p>
+            <div id="customMixOptions" class="custom-mix-options"></div>
+            <div id="customMixSummary" class="custom-mix-summary">Total: 0%</div>
+            <div id="customMixError" class="custom-mix-error"></div>
+        </div>
     </div>
     <div id="boardArea">
         <div id="boardWrapper">

--- a/styles.css
+++ b/styles.css
@@ -264,3 +264,88 @@ body {
     background-color: #4caf50;
     color: #fff;
 }
+
+.custom-mix-container {
+    margin-top: 12px;
+    padding: 12px;
+    background: #ffffff;
+    border-radius: 6px;
+    border: 1px solid #e0e0e0;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.custom-mix-description {
+    margin: 0 0 8px;
+    font-size: 14px;
+    color: #333;
+}
+
+.custom-mix-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.custom-mix-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    border: 1px solid #ededed;
+    border-radius: 6px;
+    background: #fafafa;
+}
+
+.custom-mix-row-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.custom-mix-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.custom-mix-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.custom-mix-controls input[type="range"] {
+    flex: 1;
+}
+
+.custom-mix-number {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 72px;
+}
+
+.custom-mix-number input {
+    width: 60px;
+    padding: 4px;
+}
+
+.custom-mix-controls input[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.custom-mix-summary {
+    margin-top: 10px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.custom-mix-error {
+    margin-top: 4px;
+    min-height: 18px;
+    font-size: 13px;
+    color: #c0392b;
+}


### PR DESCRIPTION
## Summary
- add a Custom mix bot option with UI controls for weighting available bots
- implement weighted bot selection per turn with fallback to the selected mix
- update evaluation handling and styling to support the configurable mix panel

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1ebb1fc40832da20187a0ae9f27da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Custom mix” bot difficulty with per-bot selection and weighted percentages.
  * Interactive controls (checkboxes, sliders, numeric inputs) with live summary and validation (at least two bots, totals = 100%).
  * Strategy selector now supports random, stockfish, or a resolved custom mix each turn.
  * Evaluation display respects selected strategy and visibility rules.
  * Defaults initialized and UI shown/hidden based on mode and difficulty.

* **Style**
  * Introduced cohesive styling for the custom mix UI, including rows, controls, summary, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->