### PR TITLE
Add worst-move bot and fix evaluation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <label for="botDifficulty">Bot:</label>
         <select id="botDifficulty">
             <option value="random">Random Moves</option>
+            <option value="worst">Worst Moves</option>
             <option value="stockfish">Stockfish</option>
             <option value="custom">Custom mix</option>
         </select>


### PR DESCRIPTION
## Summary
- add a "Worst Moves" bot option and strategy that picks the move that maximizes White's material advantage when Black plays
- update Stockfish evaluation handling so the bar always reflects White's perspective and resets when no engine evaluation is available

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d1f21df0cc832d84093f4f60b9add4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Worst Moves” bot mode in the Bot selection dropdown, choosing intentionally bad moves for a fun challenge.
  * Evaluation bar now respects the side to move, displaying scores from the correct perspective.
  * Evaluation bar resets to a neutral state when engine analysis is unavailable or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->