### PR TITLE
Fix duplicate cloneBoardState declaration

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1851,10 +1851,6 @@ document.addEventListener("DOMContentLoaded", () => {
         king: 20000
     };
 
-    const cloneBoardState = (board) => {
-        return board.map(row => row.map(cell => (cell ? { ...cell } : null)));
-    };
-
     const applyMoveForEvaluation = (board, fromRow, fromCol, toRow, toCol, pieceData) => {
         const movingPiece = { ...pieceData };
         board[fromRow][fromCol] = null;


### PR DESCRIPTION
## Summary
- remove the second cloneBoardState declaration so the original helper is used everywhere
- resolve the SyntaxError that prevented bot setup helpers from being registered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1febe8ddc832d9a7f746748b9d23c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a redundant internal function to reduce duplication and streamline the codebase. No changes to features, behavior, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->