### PR TITLE
Handle missing SharedArrayBuffer support for Stockfish

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
             <option value="stockfish">Stockfish</option>
             <option value="custom">Custom mix</option>
         </select>
+        <div id="stockfishStatus" class="stockfish-status" role="status" aria-live="polite"></div>
         <div id="customMixContainer" class="custom-mix-container" style="display: none;">
             <p class="custom-mix-description">Select at least two bots and distribute their turn percentages. Values snap to 5% increments.</p>
             <div id="customMixOptions" class="custom-mix-options"></div>
@@ -103,7 +104,6 @@
             <div id="moveHistoryList"></div>
         </div>
     </div>
-    <script src="stockfish.js"></script>
     <script src="chess.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,18 @@ body {
     white-space: nowrap;
 }
 
+.stockfish-status {
+    margin-top: 8px;
+    font-size: 14px;
+    color: #2e7d32;
+    line-height: 1.4;
+    display: none;
+}
+
+.stockfish-status.stockfish-status--error {
+    color: #c0392b;
+}
+
 #chessboard {
     display: grid;
     grid-template-columns: repeat(8, 60px);


### PR DESCRIPTION
## Summary
- add runtime checks for SharedArrayBuffer support before starting the Stockfish worker and surface a warning when the engine cannot run
- disable Stockfish-based bot options when unavailable and fall back to a safe strategy so the game continues
- add UI styling for the new status message and load only the main script to avoid SharedArrayBuffer errors on page load

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d203f34f64832daa390fc627079662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stockfish availability detection with a visible status indicator.
  * Accessible live status updates for engine availability and errors.

* **Improvements**
  * Bot selection disables Stockfish when unavailable and provides guidance.
  * Automatic fallback to random moves if the engine can’t run.
  * Custom mix automatically excludes Stockfish when unavailable.
  * Clear error styling for engine-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->