### PR TITLE
Add captured piece indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,25 @@
         </div>
     </div>
     <div id="boardArea">
-        <div id="boardWrapper">
-            <div id="chessboard"></div>
-            <div id="evalBar"><div id="evalFill"></div></div>
+        <div class="board-with-captures">
+            <div class="captured-pieces captured-white">
+                <span class="captured-label">White Captures</span>
+                <div class="captured-info">
+                    <div class="captured-list" id="whiteCapturedPieces"></div>
+                    <span class="captured-advantage" id="whiteMaterialAdvantage"></span>
+                </div>
+            </div>
+            <div id="boardWrapper">
+                <div id="chessboard"></div>
+                <div id="evalBar"><div id="evalFill"></div></div>
+            </div>
+            <div class="captured-pieces captured-black">
+                <span class="captured-label">Black Captures</span>
+                <div class="captured-info">
+                    <div class="captured-list" id="blackCapturedPieces"></div>
+                    <span class="captured-advantage" id="blackMaterialAdvantage"></span>
+                </div>
+            </div>
         </div>
         <div id="historyColumn">
             <div class="history-header">Move History</div>

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,52 @@ body {
     gap: 20px;
 }
 
+#boardArea .board-with-captures {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+.captured-pieces {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: #333;
+    font-size: 14px;
+    justify-content: center;
+}
+
+.captured-pieces .captured-label {
+    font-weight: 600;
+}
+
+.captured-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.captured-list {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 28px;
+}
+
+.captured-list img,
+.captured-piece-icon {
+    width: 26px;
+    height: 26px;
+}
+
+.captured-advantage {
+    min-width: 24px;
+    font-weight: 600;
+    color: #2f80ed;
+    text-align: center;
+}
+
 #boardWrapper {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- add captured piece sections above and below the board to show captured pieces and material advantage
- style the captured piece display to align with the existing layout
- track captured pieces within the game state so the UI updates during play and when navigating history

## Testing
- node --check chess.js

------
https://chatgpt.com/codex/tasks/task_e_68d30b706fa0832da6d8e60bb4b79476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added captured pieces panels for White and Black around the board.
  * Introduced a live material advantage indicator that updates on captures.
  * Captured pieces and advantage persist across game loads/setups and reset correctly for new games.

* Style
  * Implemented layout and styling for the captured pieces UI, including labels, icon sizing, spacing, and a compact advantage badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->