### PR TITLE
Add zero-player mode and dual bot configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
             <select id="gameModeSelect" onchange="toggleBotSelection()">
                 <option value="twoPlayer">Two Players</option>
                 <option value="onePlayer">One Player (vs. Bot)</option>
+                <option value="zeroPlayer">Zero Players (Bot vs. Bot)</option>
             </select>
         </div>
         <div class="settings-group">
@@ -26,19 +27,36 @@
         </div>
     </div>
 
-    <div id="botSelection" style="display: none;">
-        <label for="botDifficulty">Bot:</label>
-        <select id="botDifficulty">
-            <option value="random">Random Moves</option>
-            <option value="worst">Worst Moves</option>
-            <option value="stockfish">Stockfish</option>
-            <option value="custom">Custom mix</option>
-        </select>
-        <div id="customMixContainer" class="custom-mix-container" style="display: none;">
-            <p class="custom-mix-description">Select at least two bots and distribute their turn percentages. Values snap to 5% increments.</p>
-            <div id="customMixOptions" class="custom-mix-options"></div>
-            <div id="customMixSummary" class="custom-mix-summary">Total: 0%</div>
-            <div id="customMixError" class="custom-mix-error"></div>
+    <div id="botSelection" class="bot-selection" style="display: none;">
+        <div class="bot-selection-group" data-color="w">
+            <label for="whiteBotDifficulty">White Bot:</label>
+            <select id="whiteBotDifficulty" class="bot-difficulty">
+                <option value="random">Random Moves</option>
+                <option value="worst">Worst Moves</option>
+                <option value="stockfish">Stockfish</option>
+                <option value="custom">Custom mix</option>
+            </select>
+            <div class="custom-mix-container" data-color="w" style="display: none;">
+                <p class="custom-mix-description">Select at least two bots and distribute their turn percentages. Values snap to 5% increments.</p>
+                <div class="custom-mix-options" data-color="w"></div>
+                <div class="custom-mix-summary" data-color="w">Total: 0%</div>
+                <div class="custom-mix-error" data-color="w"></div>
+            </div>
+        </div>
+        <div class="bot-selection-group" data-color="b">
+            <label for="blackBotDifficulty">Black Bot:</label>
+            <select id="blackBotDifficulty" class="bot-difficulty">
+                <option value="random">Random Moves</option>
+                <option value="worst">Worst Moves</option>
+                <option value="stockfish">Stockfish</option>
+                <option value="custom">Custom mix</option>
+            </select>
+            <div class="custom-mix-container" data-color="b" style="display: none;">
+                <p class="custom-mix-description">Select at least two bots and distribute their turn percentages. Values snap to 5% increments.</p>
+                <div class="custom-mix-options" data-color="b"></div>
+                <div class="custom-mix-summary" data-color="b">Total: 0%</div>
+                <div class="custom-mix-error" data-color="b"></div>
+            </div>
         </div>
     </div>
     <div id="customSetupModal" class="custom-setup-modal hidden">

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,32 @@ body {
     flex-wrap: wrap;
 }
 
+.bot-selection {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+}
+
+.bot-selection-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 220px;
+}
+
+.bot-selection-group label {
+    font-weight: 600;
+}
+
+.bot-selection-group select {
+    padding: 5px;
+    font-size: 16px;
+}
+
 .settings-container label {
     margin-right: 10px;
 }


### PR DESCRIPTION
## Summary
- add a zero-player mode with independent bot selectors and custom mix controls for each color
- update turn handling so any bot-controlled color auto-plays while human input is blocked appropriately
- adjust styling to present the dual bot configuration panels alongside existing settings

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3105a21b0832d9d02e7744829eeee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-color bot configuration for White and Black, enabling independent bot selection and custom mixes for each side.
  * Introduced a Zero Players (Bot vs. Bot) game mode.
  * Enhanced bot behavior to respect side-specific settings and turns.

* **Style**
  * Added new styles for the per-color bot selection UI, including grouped layout, labels, and improved spacing for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->