### PR TITLE
Add start/stop controls for zero player mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
                 <option value="zeroPlayer">Zero Players (Bot vs. Bot)</option>
             </select>
         </div>
+        <div class="settings-group" id="zeroPlayerControls">
+            <button type="button" id="startZeroPlayerButton" class="zero-player-button zero-player-start">Start Auto-Play</button>
+            <button type="button" id="stopZeroPlayerButton" class="zero-player-button zero-player-stop">Stop Auto-Play</button>
+        </div>
         <div class="settings-group">
             <label for="gameTypeSelect">Game Type:</label>
             <select id="gameTypeSelect">

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,47 @@ body {
     flex-wrap: wrap;
 }
 
+#zeroPlayerControls {
+    display: none;
+}
+
+.zero-player-button {
+    padding: 6px 12px;
+    font-size: 14px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    color: #fff;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.zero-player-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.zero-player-start {
+    background: #27ae60;
+    border-color: #1e874b;
+}
+
+.zero-player-start:hover:not(:disabled),
+.zero-player-start:focus:not(:disabled) {
+    background: #1e874b;
+    border-color: #16643a;
+}
+
+.zero-player-stop {
+    background: #eb5757;
+    border-color: #c0392b;
+}
+
+.zero-player-stop:hover:not(:disabled),
+.zero-player-stop:focus:not(:disabled) {
+    background: #c0392b;
+    border-color: #922b21;
+}
+
 .bot-selection {
     width: 100%;
     display: flex;


### PR DESCRIPTION
## Summary
- add start/stop auto-play controls to the zero-player mode UI
- style the new controls and manage zero-player pause state in the game logic
- ensure bot scheduling respects the pause state and updates when the game ends

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d32b9dde44832daac35d729b4f4fd3