### PR TITLE
Ensure zero-player mode starts paused

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -99,7 +99,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let engine;
     let gameOver = false;
     let pendingBotMoveTimeout = null;
-    let zeroPlayerPaused = false;
+    let zeroPlayerPaused = true;
     const promMap = { q: 'queen', r: 'rook', b: 'bishop', n: 'knight' };
     const moveHistoryList = document.getElementById('moveHistoryList');
     let moveHistoryEntries = [];
@@ -379,7 +379,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     gameModeSelect.addEventListener("change", () => {
         gameMode = gameModeSelect.value;
-        zeroPlayerPaused = false;
+        zeroPlayerPaused = gameMode === 'zeroPlayer';
         cancelScheduledBotMove();
         updateBotSelectionVisibility();
         updateCustomMixVisibility();


### PR DESCRIPTION
## Summary
- initialize the zero-player pause flag to true so automation controls start in a paused state
- update the game mode change handler to keep zero-player mode paused until Start is pressed

## Testing
- node /tmp/pwtest/manual-zero-player-test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4105943cc832d8ac1744b4ce86c63