### PR TITLE
Allow choosing player color in single-player mode

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -39,6 +39,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const zeroPlayerControls = document.getElementById('zeroPlayerControls');
     const zeroPlayerStartButton = document.getElementById('startZeroPlayerButton');
     const zeroPlayerStopButton = document.getElementById('stopZeroPlayerButton');
+    const playerColorSelect = document.getElementById('playerColorSelect');
+    const playerColorGroup = document.getElementById('playerColorGroup');
 
     const botOptions = [
         { id: 'random', label: 'Random Moves' },
@@ -89,6 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let turn = 'w'; // 'w' for white, 'b' for black
     let lastMove = null; // To keep track of the last move
     let gameMode = 'twoPlayer'; // Default game mode
+    let playerColor = playerColorSelect ? (playerColorSelect.value === 'b' ? 'b' : 'w') : 'w';
     const botDifficulty = {
         w: botSelectors.w ? botSelectors.w.value : 'random',
         b: botSelectors.b ? botSelectors.b.value : 'random'
@@ -380,7 +383,11 @@ document.addEventListener("DOMContentLoaded", () => {
     gameModeSelect.addEventListener("change", () => {
         gameMode = gameModeSelect.value;
         zeroPlayerPaused = gameMode === 'zeroPlayer';
+        if (playerColorSelect) {
+            playerColor = playerColorSelect.value === 'b' ? 'b' : 'w';
+        }
         cancelScheduledBotMove();
+        updatePlayerColorVisibility();
         updateBotSelectionVisibility();
         updateCustomMixVisibility();
         updateZeroPlayerControlsState();
@@ -417,6 +424,21 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         });
     });
+
+    if (playerColorSelect) {
+        playerColorSelect.addEventListener('change', () => {
+            const selectedColor = playerColorSelect.value === 'b' ? 'b' : 'w';
+            if (selectedColor === playerColor) {
+                return;
+            }
+            playerColor = selectedColor;
+            cancelScheduledBotMove();
+            updateBotSelectionVisibility();
+            updateCustomMixVisibility();
+            evaluateBoard();
+            resetGame();
+        });
+    }
 
     if (zeroPlayerStartButton) {
         zeroPlayerStartButton.addEventListener('click', () => {
@@ -795,9 +817,17 @@ document.addEventListener("DOMContentLoaded", () => {
         return entries[entries.length - 1].id;
     }
 
+    function updatePlayerColorVisibility() {
+        if (!playerColorGroup) {
+            return;
+        }
+        const shouldShow = gameMode === 'onePlayer';
+        playerColorGroup.style.display = shouldShow ? 'flex' : 'none';
+    }
+
     function getBotControlledColors() {
         if (gameMode === 'onePlayer') {
-            return ['b'];
+            return playerColor === 'b' ? ['w'] : ['b'];
         }
         if (gameMode === 'zeroPlayer') {
             return ['w', 'b'];
@@ -3233,6 +3263,7 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     window.toggleBotSelection = function() {
+        updatePlayerColorVisibility();
         updateBotSelectionVisibility();
         updateCustomMixVisibility();
     };
@@ -3267,6 +3298,7 @@ document.addEventListener("DOMContentLoaded", () => {
         renderCustomMixOptions(color);
         initializeCustomMixDefaults(color);
     });
+    updatePlayerColorVisibility();
     updateCustomMixVisibility();
     updateBotSelectionVisibility();
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
                 <option value="zeroPlayer">Zero Players (Bot vs. Bot)</option>
             </select>
         </div>
+        <div class="settings-group" id="playerColorGroup" style="display: none;">
+            <label for="playerColorSelect">Player Color:</label>
+            <select id="playerColorSelect">
+                <option value="w">White</option>
+                <option value="b">Black</option>
+            </select>
+        </div>
         <div class="settings-group" id="zeroPlayerControls">
             <button type="button" id="startZeroPlayerButton" class="zero-player-button zero-player-start">Start Auto-Play</button>
             <button type="button" id="stopZeroPlayerButton" class="zero-player-button zero-player-stop">Stop Auto-Play</button>


### PR DESCRIPTION
## Summary
- add a player color selector to the single-player UI so people can choose white or black
- update the game logic to honor the selected player color when determining bot-controlled sides and when resetting games

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d415e96d18832dae1b79867e8e597b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose your playing color (White or Black) in one-player and zero-player modes.
  * Color picker appears only when relevant and updates instantly.
  * Bot automatically plays the opposite color you select; related controls adjust accordingly.
  * Changing color cancels any pending bot moves, refreshes visibility, re-evaluates the board, and may reset the game to keep state consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->