### PR TITLE
Adjust board flip behaviors

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -832,29 +832,21 @@ document.addEventListener("DOMContentLoaded", () => {
         return entries[entries.length - 1].id;
     }
 
-    function shouldFlipOrientationWithTurn() {
-        if (boardFlipMode === 'pieces') {
-            if (gameMode === 'twoPlayer') {
-                return true;
-            }
-            if (gameMode === 'zeroPlayer') {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function determineBoardOrientation() {
-        if (boardFlipMode === 'entire') {
-            return 'w';
-        }
-        if (shouldFlipOrientationWithTurn()) {
+    function getPerspectiveOrientation() {
+        if (gameMode === 'twoPlayer' || gameMode === 'zeroPlayer') {
             return turn;
         }
         if (gameMode === 'onePlayer' && playerColor === 'b') {
             return 'b';
         }
         return 'w';
+    }
+
+    function determineBoardOrientation() {
+        if (boardFlipMode === 'pieces') {
+            return 'w';
+        }
+        return getPerspectiveOrientation();
     }
 
     function updateBoardOrientationState(options = {}) {
@@ -873,9 +865,11 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!boardWithCaptures) {
             return;
         }
-        const shouldFlipEntireBoard = boardFlipMode === 'entire' && turn === 'b';
+        const perspectiveOrientation = getPerspectiveOrientation();
+        const shouldRotatePieces = boardFlipMode === 'pieces' && perspectiveOrientation === 'b';
         boardWithCaptures.classList.toggle('entire-board-mode', boardFlipMode === 'entire');
-        boardWithCaptures.classList.toggle('entire-board-flipped', shouldFlipEntireBoard);
+        boardWithCaptures.classList.remove('entire-board-flipped');
+        boardWithCaptures.classList.toggle('pieces-rotated', shouldRotatePieces);
     }
 
     function updatePlayerColorVisibility() {

--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,7 @@ body {
 .piece {
     width: 60px;
     height: 60px;
+    transition: transform 0.3s ease;
 }
 
 .move-dot {
@@ -220,6 +221,10 @@ body {
 }
 
 #boardArea .board-with-captures.entire-board-flipped {
+    transform: rotate(180deg);
+}
+
+#boardArea .board-with-captures.pieces-rotated .piece {
     transform: rotate(180deg);
 }
 


### PR DESCRIPTION
## Summary
- update orientation logic so the entire board mode now follows the active perspective while pieces mode keeps the board static
- rotate individual pieces 180° in pieces-only mode and add a smooth transition when the perspective changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d56d94df04832dabe619639377ce7a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Option to rotate only the pieces (not the whole board) in specific layouts.
  - Smooth rotation animation for pieces for a more polished experience.

- Bug Fixes
  - More consistent board perspective across game modes and player colors.
  - Correct orientation maintained when viewing captures.

- Style
  - Added a 0.3s ease transform transition to chess pieces.

- Refactor
  - Streamlined orientation handling to reduce edge cases and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->