### PR TITLE
Prevent board flipping during move history navigation

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -2761,7 +2761,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         currentHistoryIndex = clamped;
         const state = historyStates[clamped];
-        renderState(state);
+        renderState(state, { skipOrientationUpdate: true });
         updateMoveHistoryUI();
         const popup = document.querySelector('.checkmate-popup');
         if (popup) {


### PR DESCRIPTION
## Summary
- keep the current board orientation when navigating through move history entries
- avoid forcing a perspective change by skipping orientation updates during history playback

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6e88abfcc832d9f13b36da0fd8782