### PR TITLE
Add login and signup UI modals

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -44,6 +44,90 @@ document.addEventListener("DOMContentLoaded", () => {
     const boardFlipModeSelect = document.getElementById('boardFlipModeSelect');
     const boardFlipModeGroup = boardFlipModeSelect ? boardFlipModeSelect.closest('.settings-group') : null;
     const boardWithCaptures = document.querySelector('.board-with-captures');
+    const loginButton = document.getElementById('loginButton');
+    const signupButton = document.getElementById('signupButton');
+    const loginModal = document.getElementById('loginModal');
+    const signupModal = document.getElementById('signupModal');
+    const authCloseButtons = document.querySelectorAll('.auth-close-button');
+    const loginForm = document.getElementById('loginForm');
+    const signupForm = document.getElementById('signupForm');
+    const pageBody = document.body;
+
+    function openAuthModal(modal) {
+        if (!modal) {
+            return;
+        }
+        modal.classList.remove('hidden');
+        modal.setAttribute('aria-hidden', 'false');
+        pageBody.classList.add('modal-open');
+        const firstInput = modal.querySelector('input');
+        if (firstInput) {
+            firstInput.focus();
+        }
+    }
+
+    function closeAuthModal(modal) {
+        if (!modal) {
+            return;
+        }
+        modal.classList.add('hidden');
+        modal.setAttribute('aria-hidden', 'true');
+        if (![loginModal, signupModal].some(element => element && !element.classList.contains('hidden'))) {
+            pageBody.classList.remove('modal-open');
+        }
+    }
+
+    function closeAllAuthModals() {
+        [loginModal, signupModal].forEach(modal => closeAuthModal(modal));
+    }
+
+    if (loginButton && loginModal) {
+        loginButton.addEventListener('click', () => openAuthModal(loginModal));
+    }
+
+    if (signupButton && signupModal) {
+        signupButton.addEventListener('click', () => openAuthModal(signupModal));
+    }
+
+    [loginModal, signupModal].forEach(modal => {
+        if (!modal) {
+            return;
+        }
+        modal.addEventListener('click', event => {
+            if (event.target === modal) {
+                closeAuthModal(modal);
+            }
+        });
+    });
+
+    authCloseButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            const modal = button.closest('.auth-modal');
+            if (modal) {
+                closeAuthModal(modal);
+            }
+        });
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            closeAllAuthModals();
+        }
+    });
+
+    if (loginForm && loginModal) {
+        loginForm.addEventListener('submit', event => {
+            event.preventDefault();
+            closeAuthModal(loginModal);
+        });
+    }
+
+    if (signupForm && signupModal) {
+        signupForm.addEventListener('submit', event => {
+            event.preventDefault();
+            closeAuthModal(signupModal);
+        });
+    }
 
     const botOptions = [
         { id: 'random', label: 'Random Moves' },

--- a/index.html
+++ b/index.html
@@ -7,6 +7,28 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <header class="top-bar">
+        <div class="auth-buttons">
+            <button id="loginButton" class="auth-button" type="button" aria-haspopup="dialog" aria-controls="loginModal">
+                <span class="auth-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img" focusable="false">
+                        <path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"></path>
+                        <path d="M8 13h8v2H8z"></path>
+                    </svg>
+                </span>
+                <span class="auth-label">Log In</span>
+            </button>
+            <button id="signupButton" class="auth-button primary" type="button" aria-haspopup="dialog" aria-controls="signupModal">
+                <span class="auth-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" role="img" focusable="false">
+                        <path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h11.5a6.48 6.48 0 0 1-1.5-4 6.5 6.5 0 0 1 6.5-6.5 6.44 6.44 0 0 1 3.5 1.02V15c-1-.66-2.28-1-3.5-1a4.5 4.5 0 0 0-4.5 4.5 4.43 4.43 0 0 0 .25 1.5H22v-1c0-3.33-6.67-5-10-5z"></path>
+                        <path d="M19 11v-2h-2V7h2V5h2v2h2v2h-2v2z"></path>
+                    </svg>
+                </span>
+                <span class="auth-label">Sign Up</span>
+            </button>
+        </div>
+    </header>
     <div class="settings-container">
         <div class="settings-group">
             <label for="gameModeSelect">Game Mode:</label>
@@ -155,6 +177,32 @@
         <div id="historyColumn">
             <div class="history-header">Move History</div>
             <div id="moveHistoryList"></div>
+        </div>
+    </div>
+    <div id="loginModal" class="auth-modal hidden" role="dialog" aria-modal="true" aria-labelledby="loginModalTitle" aria-hidden="true">
+        <div class="auth-dialog">
+            <button type="button" class="auth-close-button" aria-label="Close login form">&times;</button>
+            <h2 id="loginModalTitle">Log In</h2>
+            <form id="loginForm">
+                <label for="loginUsername">Username</label>
+                <input id="loginUsername" name="username" type="text" autocomplete="username" required>
+                <label for="loginPassword">Password</label>
+                <input id="loginPassword" name="password" type="password" autocomplete="current-password" required>
+                <button type="submit" class="auth-submit-button">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div id="signupModal" class="auth-modal hidden" role="dialog" aria-modal="true" aria-labelledby="signupModalTitle" aria-hidden="true">
+        <div class="auth-dialog">
+            <button type="button" class="auth-close-button" aria-label="Close sign up form">&times;</button>
+            <h2 id="signupModalTitle">Create Account</h2>
+            <form id="signupForm">
+                <label for="signupUsername">Username</label>
+                <input id="signupUsername" name="username" type="text" autocomplete="username" required>
+                <label for="signupPassword">Password</label>
+                <input id="signupPassword" name="password" type="password" autocomplete="new-password" required>
+                <button type="submit" class="auth-submit-button">Create Account</button>
+            </form>
         </div>
     </div>
     <script src="stockfish.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,145 @@ body {
     margin: 0;
 }
 
+
+body.modal-open {
+    overflow: hidden;
+}
+
+.top-bar {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 12px 16px 0 16px;
+    box-sizing: border-box;
+}
+
+.auth-buttons {
+    display: flex;
+    gap: 12px;
+}
+
+.auth-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px;
+    font-size: 14px;
+    border-radius: 999px;
+    border: 1px solid #2f80ed;
+    background: #ffffff;
+    color: #2f80ed;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-button.primary {
+    background: #2f80ed;
+    color: #ffffff;
+}
+
+.auth-button:hover,
+.auth-button:focus {
+    background: #1b63c5;
+    color: #ffffff;
+    border-color: #1b63c5;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.auth-icon svg {
+    width: 18px;
+    height: 18px;
+    fill: currentColor;
+}
+
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 2100;
+    padding: 20px;
+}
+
+.auth-dialog {
+    background: #ffffff;
+    padding: 24px 28px;
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
+    width: min(360px, 100%);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.auth-dialog h2 {
+    margin: 0;
+    font-size: 22px;
+    text-align: center;
+}
+
+.auth-dialog form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.auth-dialog label {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.auth-dialog input {
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid #d0d0d0;
+    font-size: 15px;
+}
+
+.auth-dialog input:focus {
+    outline: none;
+    border-color: #2f80ed;
+    box-shadow: 0 0 0 2px rgba(47, 128, 237, 0.15);
+}
+
+.auth-submit-button {
+    padding: 10px 14px;
+    border: none;
+    border-radius: 6px;
+    background: #27ae60;
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.auth-submit-button:hover,
+.auth-submit-button:focus {
+    background: #1f8a4d;
+}
+
+.auth-close-button {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: none;
+    border: none;
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    color: #666666;
+}
+
+.auth-close-button:hover,
+.auth-close-button:focus {
+    color: #2f80ed;
+}
+
 .settings-container {
     width: 100%;
     padding: 10px 16px;


### PR DESCRIPTION
## Summary
- add a top-right authentication toolbar with login and sign-up buttons
- introduce styled authentication modals that collect username and password
- wire up modal open/close behavior and placeholder form handlers

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d6f7c87bc0832da5abe1c8c7a48612