### PR TITLE
Update RestDB collection defaults

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -57,11 +57,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const authStatusText = document.getElementById('authStatusText');
     const logoutButton = document.getElementById('logoutButton');
     const restDbBaseUrlAttribute = pageBody && pageBody.dataset ? pageBody.dataset.restdbBaseUrl : '';
-    const restDbUsersCollectionAttribute = pageBody && pageBody.dataset ? pageBody.dataset.restdbUsersCollection : '';
+    const restDbAccountsCollectionAttribute = pageBody && pageBody.dataset ? (pageBody.dataset.restdbAccountsCollection || '') : '';
+    const restDbUsersCollectionAttribute = pageBody && pageBody.dataset ? (pageBody.dataset.restdbUsersCollection || '') : '';
+    const restDbGamesCollectionAttribute = pageBody && pageBody.dataset ? (pageBody.dataset.restdbGamesCollection || '') : '';
     const restDbApiKeyAttribute = pageBody && pageBody.dataset ? pageBody.dataset.restdbApiKey : '';
     const restDbConfig = {
         baseUrl: (restDbBaseUrlAttribute || 'https://chess-7deb.restdb.io/rest').trim(),
-        usersCollection: (restDbUsersCollectionAttribute || 'users').trim(),
+        accountsCollection: (restDbAccountsCollectionAttribute || restDbUsersCollectionAttribute || 'accounts').trim(),
+        gamesCollection: (restDbGamesCollectionAttribute || 'games').trim(),
         apiKey: (restDbApiKeyAttribute || '68d6f8a9b349a33f8d4b70d8').trim()
     };
     const AUTH_STORAGE_KEY = 'chess-auth-user';
@@ -132,7 +135,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function fetchUserByUsername(username) {
-        const collectionName = restDbConfig.usersCollection || 'users';
+        const collectionName = restDbConfig.accountsCollection || 'accounts';
         const query = encodeURIComponent(JSON.stringify({ username }));
         const response = await restDbFetch(`${collectionName}?q=${query}&max=1`);
         const data = await response.json();
@@ -143,7 +146,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function createUserRecord(username, password) {
-        const collectionName = restDbConfig.usersCollection || 'users';
+        const collectionName = restDbConfig.accountsCollection || 'accounts';
         const payload = { username, password };
         const response = await restDbFetch(collectionName, {
             method: 'POST',

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Chess Game</title>
     <link rel="stylesheet" href="styles.css">
 </head>
-<body data-restdb-base-url="https://chess-7deb.restdb.io/rest" data-restdb-users-collection="users" data-restdb-api-key="68d6f8a9b349a33f8d4b70d8">
+<body data-restdb-base-url="https://chess-7deb.restdb.io/rest" data-restdb-accounts-collection="accounts" data-restdb-games-collection="games" data-restdb-api-key="68d6f8a9b349a33f8d4b70d8">
     <header class="top-bar">
         <div class="auth-buttons">
             <button id="loginButton" class="auth-button" type="button" aria-haspopup="dialog" aria-controls="loginModal">


### PR DESCRIPTION
## Summary
- default authentication requests to the `accounts` collection instead of the deprecated `users` collection
- allow configuring the games collection alongside accounts by reading new data attributes in the page markup
- update the HTML configuration attributes to point at the RestDB `accounts` and `games` collections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b6e625b8832db3c895d941f80d5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated backend data configuration for account management to improve consistency.
  - Added support in configuration for an additional games dataset.
- Chores
  - Aligned HTML data attributes with the updated configuration to ensure proper integration.
- Notes
  - No visible user interface changes in this release.
  - Existing functionality (sign-in, account usage) continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->