### PR TITLE
Remove inline game mode onchange handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <div class="settings-container">
         <div class="settings-group">
             <label for="gameModeSelect">Game Mode:</label>
-            <select id="gameModeSelect" onchange="toggleBotSelection()">
+            <select id="gameModeSelect">
                 <option value="twoPlayer">Two Players</option>
                 <option value="onePlayer">One Player (vs. Bot)</option>
                 <option value="zeroPlayer">Zero Players (Bot vs. Bot)</option>


### PR DESCRIPTION
## Summary
- remove the inline `toggleBotSelection` call from the game mode select to rely on the script-defined listener

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db20c933fc832d99457914b7d283d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a game mode no longer automatically toggles bot selection. The Game Mode dropdown no longer triggers any automatic actions, so bot settings remain unchanged until you adjust them manually. This makes switching modes predictable and avoids unintended changes to your current setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->