### PR TITLE
Fix game mode initialization order

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -78,6 +78,7 @@ document.addEventListener("DOMContentLoaded", () => {
     let authenticatedUser = null;
     const ONLINE_SEARCH_POLL_INTERVAL = 4000;
     const ONLINE_GAME_POLL_INTERVAL = 4000;
+    let gameMode = 'twoPlayer'; // Default game mode
 
     function createInitialOnlineGameState() {
         return {
@@ -1334,7 +1335,6 @@ document.addEventListener("DOMContentLoaded", () => {
     let selectedPiece = null;
     let turn = 'w'; // 'w' for white, 'b' for black
     let lastMove = null; // To keep track of the last move
-    let gameMode = 'twoPlayer'; // Default game mode
     let playerColor = playerColorSelect ? (playerColorSelect.value === 'b' ? 'b' : 'w') : 'w';
     let boardOrientation = 'w';
     let boardFlipMode = boardFlipModeSelect ? (boardFlipModeSelect.value === 'entire' ? 'entire' : 'pieces') : 'pieces';


### PR DESCRIPTION
## Summary
- initialize the gameMode state before helper functions that rely on it
- prevent ReferenceError when authentication UI updates call online state helpers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db2207ca54832d810fdd05858ddb76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Ensures the game consistently starts in two-player mode by initializing the game mode once at startup, preventing conflicts from previous duplicate declarations and reducing unexpected mode switches.

- Refactor
  - Streamlined initialization logic by removing a redundant game mode definition, improving clarity and reducing the risk of state mismatches during page load for a more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->